### PR TITLE
Add editable tasks with settings page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <button id="prev-day" class="nav-btn" aria-label="Previous Day"><i data-lucide="chevron-left"></i></button>
     <h1 id="date" class="date-title"></h1>
     <button id="next-day" class="nav-btn" aria-label="Next Day"><i data-lucide="chevron-right"></i></button>
+    <a href="settings.html" class="nav-btn" aria-label="Settings"><i data-lucide="settings"></i></a>
   </header>
 
   <main>
@@ -21,181 +22,9 @@
     <section id="task-container"></section>
   </main>
 
+  <script src="tasks.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      const tasksByDay = {
-        monday: {
-          '🌅 AM Mobility (5–10\u00a0min)': {
-            note: 'Brief morning flow to loosen spine and shoulders',
-            items: [
-              '1–2 sets Cat\u2011Cows',
-              '1–2 sets Thoracic rotations',
-              '1–2 sets Arm circles',
-              '1–2 sets Band pull-aparts'
-            ]
-          },
-          '☀️ PM Javelin Session': {
-            note: 'Dynamic warm-up, technique drills, run-up & throws',
-            items: [
-              'Dynamic warm-up: jog, skips, arm/leg swings',
-              'Throwing drills: running crossovers, elastic band drills',
-              'Lead with hip & chest, relaxed arm until final whip',
-              'Firm block leg and good shoulder layback',
-              'Eyes on target through release'
-            ]
-          },
-          '🛠️ Post-Throw Arm Care': {
-            note: 'Cooldown to recover shoulder and elbow',
-            items: [
-              'Band pull-aparts 2×15–20',
-              'External rotations 2×15 each arm',
-              'High-rep band curls & triceps ext 1×50–100',
-              'Sleeper stretch',
-              'Forearm & wrist stretches',
-              'Gentle spinal twist / thrower\u2019s stretch'
-            ]
-          }
-        },
-        tuesday: {
-          '🌙 Evening Mobility (Day\u00a01)': {
-            note: 'Hanging + Back Bridge focus',
-            items: [
-              'Quadruped straw breathing',
-              'Single leg stand',
-              'Segmented Cat‑Cow',
-              'Flexion to extension spinal hygiene',
-              'Scapula circles',
-              'Cross‑crawl supermans',
-              'Passive/Active hang 30–60s',
-              'Hanging lat stretch',
-              'Standing bridge rotations against wall',
-              'Cross-bench pullover',
-              'Optional back bridge hold',
-              'Barefoot jog/hops 5–10\u00a0min'
-            ]
-          },
-          '🛡️ Shoulder Prehab': {
-            items: [
-              'Scapular push-ups 2×15',
-              'Wall Angels 2×10',
-              'External rotation with dumbbell 2×10 each',
-              'Y‑T‑W raises 2×8 each'
-            ]
-          }
-        },
-        wednesday: {
-          '🏋️‍♂️ Gym Session (Lower Body)': {
-            note: 'Morning strength work for legs and core',
-            items: [
-              'Warm-up: cardio, leg swings, lunges',
-              'Optional plyometrics: box jumps or bounding',
-              'Trap-bar deadlift 4×5',
-              'Box squat 3×8',
-              'Split squats/lunges 3×8 each leg',
-              'Nordic curls or RDL 2×10',
-              'Back extensions 2×15',
-              'Planks or side planks 2×45s',
-              'Cooldown stretch & roll'
-            ]
-          }
-        },
-        thursday: {
-          '🌅 AM Mobility (5–10\u00a0min)': {
-            note: 'Quick activation for evening throws',
-            items: [
-              'Cat‑Cows',
-              'Arm circles',
-              'Band pull-aparts'
-            ]
-          },
-          '☀️ PM Javelin Session': {
-            note: 'Evening technical throwing practice',
-            items: [
-              'Dynamic warm-up with extra leg prep',
-              'Smooth crossovers with hip drive',
-              'Focus on tall posture then finish low',
-              'Use whole body, throw through the point'
-            ]
-          },
-          '🛠️ Post-Throw Arm Care': {
-            items: [
-              'Repeat Monday arm care routine'
-            ]
-          }
-        },
-        friday: {
-          '🏋️‍♂️ Gym Session (Upper Body)': {
-            note: 'Build pressing and pulling strength',
-            items: [
-              'Warm-up: jump rope & shoulder mobility',
-              'Bench press 5×5',
-              'Overhead med ball reverse throws 3×5',
-              'Dumbbell chest fly 3×8‑10',
-              'Single-arm dumbbell rows 3×10',
-              'Face pulls 3×12',
-              'Y‑T‑W or scap pull-ups 2×8',
-              'Pallof press/Russian twists',
-              'Stretch chest & lats'
-            ]
-          }
-        },
-        saturday: {
-          '🌙 Evening Mobility (Day\u00a02)': {
-            note: 'Side Split + Palms to Floor work',
-            items: [
-              'Quadruped straw breathing',
-              'Single leg stand',
-              'Seated leg raises',
-              'Couch stretch',
-              'Triangle pose',
-              'Toes-elevated single-leg hamstring stretch',
-              'Deep squat groin stretch',
-              'Side split push-ups',
-              'Knee-to-head marches',
-              '3-step horse stance isometric',
-              'ATG split squat pulses',
-              'Sissy squats',
-              'Wide stance alternating windmill',
-              'Iso lunge hold 2–5\u00a0min each side',
-              'Test side split & forward fold',
-              'Sprint drills or easy jog',
-              'Foam roll or extra prehab'
-            ]
-          }
-        },
-        sunday: {
-          '🌄 Recovery & Mobility (Day\u00a03)': {
-            note: 'Thrower\u2019s Stretch + Front Split focus',
-            items: [
-              'Quadruped straw breathing',
-              'Single leg stand',
-              '90/90 switches',
-              'Pigeon stretch',
-              'Wall-blocked shoulder arcs',
-              'Cross-legged side bend',
-              'Overhead lunging reach',
-              'Assisted chest stretch on floor',
-              'Eccentric front split lowering',
-              'Thoracic bridge reaches',
-              'Hold thrower\u2019s stretch with stick',
-              'Test front split',
-              'Walk or bike',
-              'Reflect & plan next week'
-            ]
-          }
-        }
-      };
-
-      const motivationByDay = {
-        monday: 'New week. New opportunities!',
-        tuesday: 'Consistency compounds results.',
-        wednesday: 'Halfway done\u2014bring the heat!',
-        thursday: 'Blast off with technique.',
-        friday: 'Leave it all on the field.',
-        saturday: 'Unlock your body\u2019s potential.',
-        sunday: 'Rest today, dominate tomorrow.'
-      };
-
       const dateEl = document.getElementById('date');
       const container = document.getElementById('task-container');
       const prevBtn = document.getElementById('prev-day');
@@ -208,8 +37,7 @@
         document.body.className = key;
         dateEl.textContent = currentDate.toLocaleDateString(undefined,{weekday:'long',month:'short',day:'numeric'});
         document.getElementById('motivation').textContent = motivationByDay[key] || '';
-        const dayData = tasksByDay[key] || {};
-
+        const dayData = getTasksFor(key, currentDate);
         for (let [group, data] of Object.entries(dayData)) {
           const groupEl = document.createElement('div');
           groupEl.className = 'task-group';

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Settings - Javelin Checklist</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="header">
+    <a href="index.html" class="nav-btn" aria-label="Back"><i data-lucide="chevron-left"></i></a>
+    <h1 class="date-title">Settings</h1>
+  </header>
+
+  <main>
+    <label for="day-select">Choose Day:</label>
+    <select id="day-select">
+      <option value="monday">Monday</option>
+      <option value="tuesday">Tuesday</option>
+      <option value="wednesday">Wednesday</option>
+      <option value="thursday">Thursday</option>
+      <option value="friday">Friday</option>
+      <option value="saturday">Saturday</option>
+      <option value="sunday">Sunday</option>
+    </select>
+    <textarea id="tasks-input" rows="15" style="width:100%;margin-top:1rem;"></textarea>
+    <button id="save-btn" style="margin-top:0.5rem;">Save</button>
+    <p style="font-size:0.8rem;margin-top:0.5rem;">Edit tasks as JSON. Changes apply from today forward.</p>
+  </main>
+
+  <script src="tasks.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const select = document.getElementById('day-select');
+      const input = document.getElementById('tasks-input');
+
+      function loadCurrent() {
+        const day = select.value;
+        const tasks = getTasksFor(day, new Date());
+        input.value = JSON.stringify(tasks, null, 2);
+      }
+
+      select.onchange = loadCurrent;
+      loadCurrent();
+
+      document.getElementById('save-btn').onclick = () => {
+        try {
+          const obj = JSON.parse(input.value);
+          saveNewTasks(select.value, obj);
+          alert('Saved!');
+        } catch(e) {
+          alert('Invalid JSON');
+        }
+      };
+
+      lucide.replace();
+    });
+  </script>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,7 @@
 const CACHE_NAME = 'javelin-checklist-v1';
 const FILES_TO_CACHE = [
-  '.', 'index.html', 'style.css', 'manifest.json', 'sw.js'
+  '.', 'index.html', 'settings.html', 'style.css',
+  'manifest.json', 'sw.js', 'tasks.js'
 ];
 self.addEventListener('install', evt => {
   evt.waitUntil(

--- a/tasks.js
+++ b/tasks.js
@@ -1,0 +1,209 @@
+// Default tasks and utilities for Javelin checklist
+const defaultTasksByDay = {
+  monday: {
+    '\uD83C\uDF05 AM Mobility (5\u201310\u00a0min)': {
+      note: 'Brief morning flow to loosen spine and shoulders',
+      items: [
+        '1\u20132 sets Cat\u2011Cows',
+        '1\u20132 sets Thoracic rotations',
+        '1\u20132 sets Arm circles',
+        '1\u20132 sets Band pull-aparts'
+      ]
+    },
+    '\u2600\uFE0F PM Javelin Session': {
+      note: 'Dynamic warm-up, technique drills, run-up & throws',
+      items: [
+        'Dynamic warm-up: jog, skips, arm/leg swings',
+        'Throwing drills: running crossovers, elastic band drills',
+        'Lead with hip & chest, relaxed arm until final whip',
+        'Firm block leg and good shoulder layback',
+        'Eyes on target through release'
+      ]
+    },
+    '\uD83D\uDEE0\uFE0F Post-Throw Arm Care': {
+      note: 'Cooldown to recover shoulder and elbow',
+      items: [
+        'Band pull-aparts 2\u00d715\u201320',
+        'External rotations 2\u00d715 each arm',
+        'High-rep band curls & triceps ext 1\u00d750\u2013100',
+        'Sleeper stretch',
+        'Forearm & wrist stretches',
+        'Gentle spinal twist / thrower\u2019s stretch'
+      ]
+    }
+  },
+  tuesday: {
+    '\uD83C\uDF19 Evening Mobility (Day\u00a01)': {
+      note: 'Hanging + Back Bridge focus',
+      items: [
+        'Quadruped straw breathing',
+        'Single leg stand',
+        'Segmented Cat\u2011Cow',
+        'Flexion to extension spinal hygiene',
+        'Scapula circles',
+        'Cross\u2011crawl supermans',
+        'Passive/Active hang 30\u201360s',
+        'Hanging lat stretch',
+        'Standing bridge rotations against wall',
+        'Cross-bench pullover',
+        'Optional back bridge hold',
+        'Barefoot jog/hops 5\u201310\u00a0min'
+      ]
+    },
+    '\uD83D\uDEE1\uFE0F Shoulder Prehab': {
+      items: [
+        'Scapular push-ups\u00a02\u00d715',
+        'Wall Angels\u00a02\u00d710',
+        'External rotation with dumbbell\u00a02\u00d710 each',
+        'Y\u2011T\u2011W raises\u00a02\u00d78 each'
+      ]
+    }
+  },
+  wednesday: {
+    '\uD83C\uDFCB\uFE0F Gym Session (Lower Body)': {
+      note: 'Morning strength work for legs and core',
+      items: [
+        'Warm-up: cardio, leg swings, lunges',
+        'Optional plyometrics: box jumps or bounding',
+        'Trap-bar deadlift\u00a04\u00d75',
+        'Box squat\u00a03\u00d78',
+        'Split squats/lunges\u00a03\u00d78 each leg',
+        'Nordic curls or RDL\u00a02\u00d710',
+        'Back extensions\u00a02\u00d715',
+        'Planks or side planks\u00a02\u00d745s',
+        'Cooldown stretch & roll'
+      ]
+    }
+  },
+  thursday: {
+    '\uD83C\uDF05 AM Mobility (5\u201310\u00a0min)': {
+      note: 'Quick activation for evening throws',
+      items: [
+        'Cat\u2011Cows',
+        'Arm circles',
+        'Band pull-aparts'
+      ]
+    },
+    '\u2600\uFE0F PM Javelin Session': {
+      note: 'Evening technical throwing practice',
+      items: [
+        'Dynamic warm-up with extra leg prep',
+        'Smooth crossovers with hip drive',
+        'Focus on tall posture then finish low',
+        'Use whole body, throw through the point'
+      ]
+    },
+    '\uD83D\uDEE0\uFE0F Post-Throw Arm Care': {
+      items: ['Repeat Monday arm care routine']
+    }
+  },
+  friday: {
+    '\uD83C\uDFCB\uFE0F Gym Session (Upper Body)': {
+      note: 'Build pressing and pulling strength',
+      items: [
+        'Warm-up: jump rope & shoulder mobility',
+        'Bench press\u00a05\u00d75',
+        'Overhead med ball reverse throws\u00a03\u00d75',
+        'Dumbbell chest fly\u00a03\u00d78\u201110',
+        'Single-arm dumbbell rows\u00a03\u00d710',
+        'Face pulls\u00a03\u00d712',
+        'Y\u2011T\u2011W or scap pull-ups\u00a02\u00d78',
+        'Pallof press/Russian twists',
+        'Stretch chest & lats'
+      ]
+    }
+  },
+  saturday: {
+    '\uD83C\uDF19 Evening Mobility (Day\u00a02)': {
+      note: 'Side Split + Palms to Floor work',
+      items: [
+        'Quadruped straw breathing',
+        'Single leg stand',
+        'Seated leg raises',
+        'Couch stretch',
+        'Triangle pose',
+        'Toes-elevated single-leg hamstring stretch',
+        'Deep squat groin stretch',
+        'Side split push-ups',
+        'Knee-to-head marches',
+        '3-step horse stance isometric',
+        'ATG split squat pulses',
+        'Sissy squats',
+        'Wide stance alternating windmill',
+        'Iso lunge hold 2\u20135\u00a0min each side',
+        'Test side split & forward fold',
+        'Sprint drills or easy jog',
+        'Foam roll or extra prehab'
+      ]
+    }
+  },
+  sunday: {
+    '\uD83C\uDF04 Recovery & Mobility (Day\u00a03)': {
+      note: 'Thrower\u2019s Stretch + Front Split focus',
+      items: [
+        'Quadruped straw breathing',
+        'Single leg stand',
+        '90/90 switches',
+        'Pigeon stretch',
+        'Wall-blocked shoulder arcs',
+        'Cross-legged side bend',
+        'Overhead lunging reach',
+        'Assisted chest stretch on floor',
+        'Eccentric front split lowering',
+        'Thoracic bridge reaches',
+        'Hold thrower\u2019s stretch with stick',
+        'Test front split',
+        'Walk or bike',
+        'Reflect & plan next week'
+      ]
+    }
+  }
+};
+
+const motivationByDay = {
+  monday: 'New week. New opportunities!',
+  tuesday: 'Consistency compounds results.',
+  wednesday: 'Halfway done\u2014bring the heat!',
+  thursday: 'Blast off with technique.',
+  friday: 'Leave it all on the field.',
+  saturday: 'Unlock your body\u2019s potential.',
+  sunday: 'Rest today, dominate tomorrow.'
+};
+
+function loadTaskHistory() {
+  let hist = localStorage.getItem('taskHistory');
+  if (hist) return JSON.parse(hist);
+  const start = '1970-01-01';
+  const h = {};
+  for (const [day, tasks] of Object.entries(defaultTasksByDay)) {
+    h[day] = [{ start, tasks }];
+  }
+  localStorage.setItem('taskHistory', JSON.stringify(h));
+  return h;
+}
+
+function saveTaskHistory(hist) {
+  localStorage.setItem('taskHistory', JSON.stringify(hist));
+}
+
+function getTasksFor(dayKey, date) {
+  const hist = loadTaskHistory();
+  const plans = hist[dayKey] || [];
+  if (!plans.length) return {};
+  const target = date.toISOString().split('T')[0];
+  let result = plans[0].tasks;
+  for (const p of plans) {
+    if (p.start <= target) result = p.tasks; else break;
+  }
+  return result;
+}
+
+function saveNewTasks(dayKey, tasks) {
+  const hist = loadTaskHistory();
+  const today = new Date().toISOString().split('T')[0];
+  if (!hist[dayKey] || !hist[dayKey].length) {
+    hist[dayKey] = [{ start: '1970-01-01', tasks: defaultTasksByDay[dayKey] || {} }];
+  }
+  hist[dayKey].push({ start: today, tasks });
+  saveTaskHistory(hist);
+}


### PR DESCRIPTION
## Summary
- pull large task list into shared `tasks.js`
- render tasks from history and include link to new settings page
- add `settings.html` to edit tasks in JSON format
- cache new assets in service worker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875140cf254832d8d189b38f464a1e4