### PR TITLE
Add custom task editor with repeat options

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <button id="prev-day" class="nav-btn" aria-label="Previous Day"><i data-lucide="chevron-left"></i></button>
     <h1 id="date" class="date-title"></h1>
     <button id="next-day" class="nav-btn" aria-label="Next Day"><i data-lucide="chevron-right"></i></button>
+    <a href="task-editor.html" class="nav-btn" aria-label="Add Task"><i data-lucide="plus"></i></a>
     <a href="settings.html" class="nav-btn" aria-label="Settings"><i data-lucide="settings"></i></a>
   </header>
 

--- a/sw.js
+++ b/sw.js
@@ -2,11 +2,14 @@ const CACHE_NAME = 'javelin-checklist-v1';
 const FILES_TO_CACHE = [
   '.',
   'index.html',
+  'task-editor.html',
   'settings.html',
   'style.css',
   'manifest.json',
   'sw.js',
   'tasks.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css',
+  'https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js',
   'https://cdn.jsdelivr.net/npm/lucide@latest/dist/lucide.min.js',
   'https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js'
 ];

--- a/task-editor.html
+++ b/task-editor.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Add Task</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/lucide@latest/dist/lucide.min.js"></script>
+</head>
+<body>
+  <header class="header">
+    <a href="index.html" class="nav-btn" aria-label="Back"><i data-lucide="chevron-left"></i></a>
+    <h1 class="date-title">New Task</h1>
+  </header>
+  <main class="container" style="margin-top:1rem;">
+    <div class="input-field">
+      <input id="label" type="text" />
+      <label for="label">Task Label</label>
+    </div>
+    <div class="input-field">
+      <input id="emoji" type="text" placeholder="\uD83D\uDE00" />
+      <label for="emoji">Emoji</label>
+    </div>
+    <div class="input-field">
+      <input id="color" type="color" value="#ff0000" style="height:2.5rem;" />
+      <label class="active" for="color">Color</label>
+    </div>
+    <p>Repeat:</p>
+    <p>
+      <label>
+        <input name="repeat" type="radio" value="daily" checked />
+        <span>Daily</span>
+      </label>
+    </p>
+    <p>
+      <label>
+        <input name="repeat" type="radio" value="weekdays" />
+        <span>Select Weekdays</span>
+      </label>
+    </p>
+    <div id="weekday-boxes" style="display:none;margin-bottom:1rem;">
+      <label style="margin-right:0.5rem;"><input type="checkbox" value="1"/><span>Mon</span></label>
+      <label style="margin-right:0.5rem;"><input type="checkbox" value="2"/><span>Tue</span></label>
+      <label style="margin-right:0.5rem;"><input type="checkbox" value="3"/><span>Wed</span></label>
+      <label style="margin-right:0.5rem;"><input type="checkbox" value="4"/><span>Thu</span></label>
+      <label style="margin-right:0.5rem;"><input type="checkbox" value="5"/><span>Fri</span></label>
+      <label style="margin-right:0.5rem;"><input type="checkbox" value="6"/><span>Sat</span></label>
+      <label style="margin-right:0.5rem;"><input type="checkbox" value="0"/><span>Sun</span></label>
+    </div>
+    <button id="add-btn" class="btn">Add Task</button>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  <script src="tasks.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const repeatRadios = document.getElementsByName('repeat');
+      const weekBox = document.getElementById('weekday-boxes');
+      repeatRadios.forEach(r => {
+        r.addEventListener('change', () => {
+          weekBox.style.display = repeatRadios[1].checked ? 'block' : 'none';
+        });
+      });
+      document.getElementById('add-btn').addEventListener('click', () => {
+        const label = document.getElementById('label').value.trim();
+        if(!label) { M.toast({text:'Label required'}); return; }
+        const emoji = document.getElementById('emoji').value.trim();
+        const color = document.getElementById('color').value;
+        let repeat;
+        if(repeatRadios[0].checked) repeat = 'daily';
+        else repeat = Array.from(weekBox.querySelectorAll('input:checked')).map(cb => parseInt(cb.value));
+        addCustomTask({label, emoji, color, repeat});
+        M.toast({text:'Task added'});
+        document.getElementById('label').value='';
+        document.getElementById('emoji').value='';
+      });
+      lucide.replace();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `task-editor.html` with Materialize components
- link new editor from the main page
- handle saving custom tasks and merging them with daily tasks
- cache new files in the service worker

## Testing
- `node -e "const fs=require('fs');console.log('ok')"`
- `node - <<'NODE'
const vm=require('vm'),fs=require('fs');const code=fs.readFileSync('tasks.js','utf8');vm.runInNewContext(code,global);
localStorage={getItem:()=>null,setItem:()=>{}};console.log(Object.keys(getTasksFor('monday',new Date('2023-08-14'))).length);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68751bd4f2c8832db5049407802cf560