### PR TITLE
Disable edits for past/future dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 
   <main>
     <p id="motivation"></p>
+    <p id="view-only-msg" class="view-only" style="display:none;">Past or future days are view-only.</p>
     <section id="task-container"></section>
   </main>
 
@@ -37,6 +38,9 @@
         document.body.className = key;
         dateEl.textContent = currentDate.toLocaleDateString(undefined,{weekday:'long',month:'short',day:'numeric'});
         document.getElementById('motivation').textContent = motivationByDay[key] || '';
+        const viewOnly = currentDate.toDateString() !== new Date().toDateString();
+        const viewMsg = document.getElementById('view-only-msg');
+        viewMsg.style.display = viewOnly ? 'block' : 'none';
         const dayData = getTasksFor(key, currentDate);
         for (let [group, data] of Object.entries(dayData)) {
           const groupEl = document.createElement('div');
@@ -53,6 +57,7 @@
             const li = document.createElement('li'); li.className='task-item';
             const chk = document.createElement('input'); chk.type='checkbox'; chk.id=id;
             chk.checked=JSON.parse(localStorage.getItem(id)||false);
+            chk.disabled = viewOnly;
             chk.addEventListener('change',()=>{
               localStorage.setItem(id,chk.checked);
               li.classList.toggle('completed',chk.checked);

--- a/style.css
+++ b/style.css
@@ -75,6 +75,13 @@ body.sunday { --accent: #EFD8B7; }
   font-weight: 600;
 }
 
+#view-only-msg {
+  text-align: center;
+  margin-bottom: 1rem;
+  font-style: italic;
+  color: #b00;
+}
+
 @media (max-width: 600px) {
   .task-item { padding: .5rem; }
   .task-group h2 { font-size: .9rem; padding: .5rem; }


### PR DESCRIPTION
## Summary
- show view-only message when viewing a day that isn't today
- disable checkbox inputs when not on today's date

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68751bd77f4c832db16a4911ea3743f7