### PR TITLE
Add customizable UI settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="manifest" href="manifest.json" />
   <script src="https://cdn.jsdelivr.net/npm/lucide@latest/dist/lucide.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+  <script src="settings.js"></script>
 </head>
 <body>
   <header class="header">
@@ -25,18 +26,27 @@
   <script src="tasks.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      const settings = loadSettings();
       const dateEl = document.getElementById('date');
       const container = document.getElementById('task-container');
       const prevBtn = document.getElementById('prev-day');
       const nextBtn = document.getElementById('next-day');
+      const motivationEl = document.getElementById('motivation');
       let currentDate = new Date();
+
+      function applyDaySettings(dayKey) {
+        const color = settings.colors[dayKey];
+        if (color) document.body.style.setProperty('--accent', color);
+        motivationEl.style.display = settings.showQuotes ? '' : 'none';
+        motivationEl.textContent = motivationByDay[dayKey] || '';
+      }
 
       function render() {
         container.innerHTML = '';
         const key = currentDate.toLocaleDateString(undefined,{weekday:'long'}).toLowerCase();
         document.body.className = key;
         dateEl.textContent = currentDate.toLocaleDateString(undefined,{weekday:'long',month:'short',day:'numeric'});
-        document.getElementById('motivation').textContent = motivationByDay[key] || '';
+        applyDaySettings(key);
         const dayData = getTasksFor(key, currentDate);
         for (let [group, data] of Object.entries(dayData)) {
           const groupEl = document.createElement('div');
@@ -58,13 +68,13 @@
               li.classList.toggle('completed',chk.checked);
               if(chk.checked) {
                 ul.appendChild(li);
-                confetti({particleCount:30,spread:55,origin:{y:0.6}});
+                confetti({particleCount:30,spread:55,origin:{y:0.6},colors:settings.confettiColors});
               } else {
                 ul.insertBefore(li,ul.children[i]);
               }
             });
             const lbl = document.createElement('label'); lbl.htmlFor=id;
-            lbl.innerHTML = `<i data-lucide='circle'></i> ${task}`;
+            lbl.innerHTML = `<span class="task-emoji">${settings.emoji}</span> ${task}`;
             li.append(chk,lbl);
             if(chk.checked) li.classList.add('completed');
             ul.appendChild(li);

--- a/settings.html
+++ b/settings.html
@@ -6,42 +6,68 @@
   <title>Settings - Javelin Checklist</title>
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
-  <header class="header">
-    <a href="index.html" class="nav-btn" aria-label="Back"><i data-lucide="chevron-left"></i></a>
-    <h1 class="date-title">Settings</h1>
-  </header>
+  <body>
+    <header class="header">
+      <a href="index.html" class="nav-btn" aria-label="Back"><i data-lucide="chevron-left"></i></a>
+      <h1 class="date-title">Settings</h1>
+    </header>
 
-  <main>
-    <label for="day-select">Choose Day:</label>
-    <select id="day-select">
-      <option value="monday">Monday</option>
-      <option value="tuesday">Tuesday</option>
-      <option value="wednesday">Wednesday</option>
-      <option value="thursday">Thursday</option>
-      <option value="friday">Friday</option>
-      <option value="saturday">Saturday</option>
-      <option value="sunday">Sunday</option>
-    </select>
-    <textarea id="tasks-input" rows="15" style="width:100%;margin-top:1rem;"></textarea>
-    <button id="save-btn" style="margin-top:0.5rem;">Save</button>
-    <p style="font-size:0.8rem;margin-top:0.5rem;">Edit tasks as JSON. Changes apply from today forward.</p>
-  </main>
+    <main>
+      <label for="day-select">Choose Day:</label>
+      <select id="day-select">
+        <option value="monday">Monday</option>
+        <option value="tuesday">Tuesday</option>
+        <option value="wednesday">Wednesday</option>
+        <option value="thursday">Thursday</option>
+        <option value="friday">Friday</option>
+        <option value="saturday">Saturday</option>
+        <option value="sunday">Sunday</option>
+      </select>
+      <label style="display:block;margin-top:0.5rem;" for="accent-input">Accent color:</label>
+      <input type="color" id="accent-input" />
+      <textarea id="tasks-input" rows="15" style="width:100%;margin-top:1rem;"></textarea>
+      <button id="save-btn" style="margin-top:0.5rem;">Save Tasks</button>
+      <p style="font-size:0.8rem;margin-top:0.5rem;">Edit tasks as JSON. Changes apply from today forward.</p>
 
-  <script src="tasks.js"></script>
+      <h2 style="margin-top:1.5rem;">Appearance</h2>
+      <label for="emoji-input">Task emoji:</label>
+      <input id="emoji-input" maxlength="2" style="width:3rem;margin-left:0.5rem;" />
+      <div style="margin-top:0.5rem;">
+        <label><input type="checkbox" id="quote-toggle"/> Show motivational quote</label>
+      </div>
+      <label style="display:block;margin-top:0.5rem;">Confetti colors:</label>
+      <input type="color" id="confetti1" />
+      <input type="color" id="confetti2" />
+      <button id="save-settings-btn" style="margin-top:0.5rem;">Save Settings</button>
+    </main>
+
+    <script src="settings.js"></script>
+    <script src="tasks.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const select = document.getElementById('day-select');
       const input = document.getElementById('tasks-input');
+      const accent = document.getElementById('accent-input');
+      const emojiInput = document.getElementById('emoji-input');
+      const quoteToggle = document.getElementById('quote-toggle');
+      const conf1 = document.getElementById('confetti1');
+      const conf2 = document.getElementById('confetti2');
+
+      const settings = loadSettings();
 
       function loadCurrent() {
         const day = select.value;
         const tasks = getTasksFor(day, new Date());
         input.value = JSON.stringify(tasks, null, 2);
+        accent.value = settings.colors[day] || '#ffffff';
       }
 
       select.onchange = loadCurrent;
       loadCurrent();
+      emojiInput.value = settings.emoji;
+      quoteToggle.checked = settings.showQuotes;
+      conf1.value = settings.confettiColors[0] || '#bb0000';
+      conf2.value = settings.confettiColors[1] || '#ffffff';
 
       document.getElementById('save-btn').onclick = () => {
         try {
@@ -51,6 +77,15 @@
         } catch(e) {
           alert('Invalid JSON');
         }
+      };
+
+      document.getElementById('save-settings-btn').onclick = () => {
+        settings.colors[select.value] = accent.value;
+        settings.emoji = emojiInput.value;
+        settings.showQuotes = quoteToggle.checked;
+        settings.confettiColors = [conf1.value, conf2.value];
+        saveSettings(settings);
+        alert('Settings saved!');
       };
 
       lucide.replace();

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,34 @@
+function loadSettings() {
+  const defaults = {
+    colors: {
+      monday: '#FFA69E',
+      tuesday: '#FFB357',
+      wednesday: '#A8E6CF',
+      thursday: '#9FA8DA',
+      friday: '#C6A7FE',
+      saturday: '#5BC8AF',
+      sunday: '#EFD8B7'
+    },
+    emoji: '\uD83D\uDCAA',
+    showQuotes: true,
+    confettiColors: ['#bb0000', '#ffffff']
+  };
+  try {
+    const saved = JSON.parse(localStorage.getItem('settings') || '{}');
+    return {
+      colors: { ...defaults.colors, ...(saved.colors || {}) },
+      emoji: saved.emoji || defaults.emoji,
+      showQuotes: typeof saved.showQuotes === 'boolean' ? saved.showQuotes : defaults.showQuotes,
+      confettiColors: saved.confettiColors || defaults.confettiColors
+    };
+  } catch (e) {
+    return defaults;
+  }
+}
+
+function saveSettings(settings) {
+  localStorage.setItem('settings', JSON.stringify(settings));
+}
+
+window.loadSettings = loadSettings;
+window.saveSettings = saveSettings;

--- a/style.css
+++ b/style.css
@@ -58,7 +58,7 @@ main { padding: 1rem; }
   accent-color: var(--accent);
 }
 .task-item label { flex: 1; display: flex; align-items: center; }
-.task-item label i { margin-right: .5rem; }
+.task-emoji { margin-right: .5rem; }
 
 /* Day color themes */
 body.monday { --accent: #FFA69E; }


### PR DESCRIPTION
## Summary
- store persistent app settings for appearance in localStorage
- allow editing task emoji, confetti colours, quote visibility and day colours in settings page
- load settings on main page and apply accent colour, emoji bullets and confetti scheme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68751bd8c884832db6edc4231995d85c