### PR TITLE
Fix React entry, icon imports and PWA assets

### DIFF
--- a/ErrorBoundary.js
+++ b/ErrorBoundary.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch(error, info) {
+    console.error(error, info);
+  }
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>;
+    }
+    return this.props.children;
+  }
+}

--- a/IconDemo.js
+++ b/IconDemo.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Check } from 'lucide-react';
+
+export default function IconDemo() {
+  return (
+    <div className="flex items-center gap-2">
+      <Check size={16} />
+      Example icon
+    </div>
+  );
+}

--- a/index.html
+++ b/index.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Javelin Training Checklist - React</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/tailwind.min.css" rel="stylesheet">
-  <link rel="manifest" href="manifest.json" />
+  <link rel="manifest" href="/manifest.json" />
+  <link rel="icon" href="/icons/favicon.ico" />
   <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://cdn.jsdelivr.net/npm/babel-standalone@6/babel.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/lucide@latest/dist/lucide.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
 </head>
 <body class="bg-gray-100 text-gray-900">
   <div id="root"></div>
-  <script type="text/babel" src="react-app.js"></script>
+  <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './react-app.js';
+import ErrorBoundary from './ErrorBoundary.js';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+
+root.render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "background_color": "#f9f9f9",
   "theme_color": "#333333",
   "icons": [
-    { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
   ]
 }

--- a/react-app.js
+++ b/react-app.js
@@ -1,3 +1,4 @@
+import { Circle } from "lucide-react";
 const { useState, useEffect } = React;
 
 const defaultTasksByDay = {
@@ -184,9 +185,12 @@ function usePersistentState(key, defaultValue) {
 
 function TaskItem({ id, label, checked, onChange }) {
   return (
-    <li className={`flex items-center border-b last:border-0 p-3 ${checked ? 'opacity-60' : ''}`}> 
+    <li className={`flex items-center border-b last:border-0 p-3 ${checked ? 'opacity-60' : ''}`}>
       <input type="checkbox" className="mr-2 h-5 w-5 accent-blue-500" id={id} checked={checked} onChange={e => onChange(e.target.checked)} />
-      <label htmlFor={id} className="flex-1" dangerouslySetInnerHTML={{__html: `<i data-lucide='circle'></i> ${label}`}}></label>
+      <label htmlFor={id} className="flex-1 flex items-center gap-2">
+        <Circle size={16} />
+        {label}
+      </label>
     </li>
   );
 }
@@ -200,7 +204,6 @@ function TaskGroup({ title, note, items, dayKey }) {
         {items.map((task, i) => {
           const id = `${dayKey}-${title}-${i}`;
           const [checked, setChecked] = usePersistentState(id, false);
-          useEffect(() => { if (checked) lucide.replace(); }, [checked]);
           const handleChange = val => {
             setChecked(val);
             if (val) confetti({ particleCount: 30, spread: 55, origin: { y: 0.6 } });
@@ -221,7 +224,6 @@ function App() {
   const nextDay = () => setDate(d => new Date(d.getTime() + 86400000));
   const prevDay = () => setDate(d => new Date(d.getTime() - 86400000));
 
-  useEffect(() => { lucide.replace(); }, [date]);
 
   return (
     <div>
@@ -240,4 +242,4 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+export default App;


### PR DESCRIPTION
## Summary
- switch to React 18 `createRoot` with an error boundary
- import lucide icons as React components
- fix PWA manifest and favicon paths
- remove placeholder icon assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfffe5a524832d977532d34d4fb323