### PR TITLE
fix: adjust paths for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Javelin Training Checklist - React</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/tailwind.min.css" rel="stylesheet">
-  <link rel="manifest" href="/manifest.json" />
-  <link rel="icon" href="/icons/favicon.ico" />
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
   <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
 </head>
 <body class="bg-gray-100 text-gray-900">
   <div id="root"></div>
-  <script type="module" src="index.js"></script>
+  <script type="module" src="%PUBLIC_URL%/index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,13 +1,8 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
 import App from './react-app.js';
 import ErrorBoundary from './ErrorBoundary.js';
 
-const container = document.getElementById('root');
-const root = createRoot(container);
+const root = ReactDOM.createRoot(document.getElementById('root'));
 
 root.render(
-  <ErrorBoundary>
-    <App />
-  </ErrorBoundary>
+  React.createElement(ErrorBoundary, null, React.createElement(App))
 );

--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,5 @@
   "start_url": ".",
   "display": "standalone",
   "background_color": "#f9f9f9",
-  "theme_color": "#333333",
-  "icons": [
-    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
-  ]
+  "theme_color": "#333333"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "javelintodo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/react-app.js
+++ b/react-app.js
@@ -1,4 +1,17 @@
-import { Circle } from "lucide-react";
+const Circle = ({ size = 16 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="10" />
+  </svg>
+);
 const { useState, useEffect } = React;
 
 const defaultTasksByDay = {


### PR DESCRIPTION
## Summary
- update index.js to use React 18 createRoot and wrap App in ErrorBoundary
- load manifest and favicon via %PUBLIC_URL% for GitHub Pages
- remove placeholder icons and clean manifest

## Testing
- `node --check index.js`
- `node -e "require('./manifest.json'); console.log('manifest valid')"`


------
https://chatgpt.com/codex/tasks/task_e_68c00685519c832d80bdb508f9bc35a6