### PR TITLE
Add settings navigation and task loading from stored settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
 
     <!-- Confetti -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+
+    <!-- Shared settings and task utilities -->
+    <script src="./settings.js"></script>
+    <script src="./tasks.js"></script>
   </head>
   <body class="bg-gray-100 text-gray-900">
     <div id="root"></div>

--- a/react-app.js
+++ b/react-app.js
@@ -1,66 +1,9 @@
 const { useState, useEffect } = React;
 
-// Simple circle icon component
-function Circle({ size = 16 }) {
-  return React.createElement(
-    "svg",
-    {
-      width: size,
-      height: size,
-      viewBox: "0 0 24 24",
-      fill: "none",
-      stroke: "currentColor",
-      strokeWidth: "2",
-      strokeLinecap: "round",
-      strokeLinejoin: "round"
-    },
-    React.createElement("circle", { cx: "12", cy: "12", r: "10" })
-  );
-}
+// Access shared utilities exposed on the window
+const { loadSettings, getTasksFor, motivationByDay } = window;
 
-// Default tasks for each day
-const defaultTasksByDay = {
-  monday: {
-    "🌅 AM Mobility (5–10 min)": {
-      note: "Brief morning flow to loosen spine and shoulders",
-      items: ["1–2 sets Cat–Cows", "1–2 sets Thoracic rotations", "1–2 sets Arm circles", "1–2 sets Band pull-aparts"]
-    },
-    "☀️ PM Javelin Session": {
-      note: "Dynamic warm-up, technique drills, run-up & throws",
-      items: [
-        "Dynamic warm-up: jog, skips, arm/leg swings",
-        "Throwing drills: running crossovers, elastic band drills",
-        "Lead with hip & chest, relaxed arm until final whip",
-        "Firm block leg and good shoulder layback",
-        "Eyes on target through release"
-      ]
-    },
-    "🛠️ Post-Throw Arm Care": {
-      note: "Cooldown to recover shoulder and elbow",
-      items: [
-        "Band pull-aparts 2×15–20",
-        "External rotations 2×15 each arm",
-        "High-rep band curls & triceps ext 1×50–100",
-        "Sleeper stretch",
-        "Forearm & wrist stretches",
-        "Gentle spinal twist / thrower’s stretch"
-      ]
-    }
-  },
-  // … (keep the rest of your tasks exactly as before)
-};
-
-const motivationByDay = {
-  monday: "New week. New opportunities!",
-  tuesday: "Consistency compounds results.",
-  wednesday: "Halfway done—bring the heat!",
-  thursday: "Blast off with technique.",
-  friday: "Leave it all on the field.",
-  saturday: "Unlock your body’s potential.",
-  sunday: "Rest today, dominate tomorrow."
-};
-
-// Persistent state hook (localStorage-backed)
+// Persistent state hook backed by localStorage
 function usePersistentState(key, defaultValue) {
   const [value, setValue] = useState(() => {
     const stored = localStorage.getItem(key);
@@ -72,8 +15,8 @@ function usePersistentState(key, defaultValue) {
   return [value, setValue];
 }
 
-// Task item component
-function TaskItem({ id, label, checked, onChange }) {
+// Individual task item
+function TaskItem({ id, label, checked, onChange, emoji }) {
   return React.createElement(
     "li",
     {
@@ -90,20 +33,30 @@ function TaskItem({ id, label, checked, onChange }) {
     }),
     React.createElement(
       "label",
-      { htmlFor: id, className: "flex-1 flex items-center gap-2" },
-      React.createElement(Circle, { size: 16 }),
-      label
+      { htmlFor: id, className: "flex-1 flex items-center" },
+      emoji && React.createElement("span", { className: "task-emoji mr-2" }, emoji),
+      React.createElement("span", {
+        dangerouslySetInnerHTML: { __html: label }
+      })
     )
   );
 }
 
-// Task group (a set of items for a category)
-function TaskGroup({ title, note, items, dayKey }) {
+// Group of related tasks
+function TaskGroup({ title, note, items, dayKey, emoji, accent }) {
   return React.createElement(
     "div",
     { className: "bg-white rounded shadow mb-4" },
-    React.createElement("h2", { className: "bg-blue-500 text-white text-sm p-2 rounded-t" }, title),
-    note && React.createElement("p", { className: "italic text-gray-600 px-4 pt-2" }, note),
+    React.createElement(
+      "h2",
+      {
+        className: "text-white text-sm p-2 rounded-t",
+        style: { background: accent }
+      },
+      title
+    ),
+    note &&
+      React.createElement("p", { className: "italic text-gray-600 px-4 pt-2" }, note),
     React.createElement(
       "ul",
       null,
@@ -121,18 +74,22 @@ function TaskGroup({ title, note, items, dayKey }) {
           id,
           label: task,
           checked,
-          onChange: handleChange
+          onChange: handleChange,
+          emoji
         });
       })
     )
   );
 }
 
-// Main App
+// Main application component
 function App() {
   const [date, setDate] = useState(new Date());
+  const [settings] = useState(() => (typeof loadSettings === "function" ? loadSettings() : {}));
+
   const dayKey = date.toLocaleDateString(undefined, { weekday: "long" }).toLowerCase();
-  const tasks = defaultTasksByDay[dayKey] || {};
+  const tasks = typeof getTasksFor === "function" ? getTasksFor(dayKey, date) : {};
+  const accent = (settings.colors && settings.colors[dayKey]) || "#3b82f6"; // default blue
 
   const nextDay = () => setDate((d) => new Date(d.getTime() + 86400000));
   const prevDay = () => setDate((d) => new Date(d.getTime() - 86400000));
@@ -140,35 +97,63 @@ function App() {
   return React.createElement(
     "div",
     null,
-    // Header
     React.createElement(
       "header",
-      { className: "flex items-center justify-between p-4 bg-blue-500 text-white shadow" },
-      React.createElement("button", { onClick: prevDay, className: "text-xl" }, "⬅️"),
+      {
+        className: "flex items-center justify-between p-4 text-white shadow",
+        style: { background: accent }
+      },
       React.createElement(
         "h1",
-        { className: "text-lg flex-1 text-center" },
-        date.toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })
+        {
+          className: "flex-1 flex items-center justify-center gap-4 text-lg"
+        },
+        React.createElement(
+          "button",
+          { onClick: prevDay, className: "text-xl", "aria-label": "Previous day" },
+          "⬅️"
+        ),
+        date.toLocaleDateString(undefined, {
+          weekday: "long",
+          month: "short",
+          day: "numeric"
+        }),
+        React.createElement(
+          "button",
+          { onClick: nextDay, className: "text-xl", "aria-label": "Next day" },
+          "➡️"
+        )
       ),
-      React.createElement("button", { onClick: nextDay, className: "text-xl" }, "➡️")
+      React.createElement(
+        "a",
+        { href: "settings.html", className: "ml-4 underline" },
+        "Settings"
+      )
     ),
-    // Main content
     React.createElement(
       "main",
       { className: "p-4" },
-      React.createElement("p", { className: "text-center font-semibold mb-4" }, motivationByDay[dayKey] || ""),
+      settings.showQuotes &&
+        React.createElement(
+          "p",
+          { className: "text-center font-semibold mb-4" },
+          (motivationByDay && motivationByDay[dayKey]) || ""
+        ),
       Object.entries(tasks).map(([group, data]) =>
         React.createElement(TaskGroup, {
           key: group,
           title: group,
           note: data.note,
           items: data.items,
-          dayKey
+          dayKey,
+          emoji: settings.emoji,
+          accent
         })
       )
     )
   );
 }
 
-// Expose globally for index.js
+// Expose App for index.js
 window.App = App;
+

--- a/tasks.js
+++ b/tasks.js
@@ -239,3 +239,7 @@ function saveNewTasks(dayKey, tasks) {
   hist[dayKey].push({ start: today, tasks });
   saveTaskHistory(hist);
 }
+
+// Expose key utilities globally for modules
+window.getTasksFor = getTasksFor;
+window.motivationByDay = motivationByDay;


### PR DESCRIPTION
## Summary
- load shared settings and task utilities on the home page
- render task list from saved settings with configurable emoji and quote toggle
- add Settings link to header and place day navigation arrows around the date

## Testing
- ⚠️ `npm test` (no tests configured)


------
https://chatgpt.com/codex/tasks/task_e_68c0198cdec0832d9d83a9a17fc62711