### PR TITLE
Register service worker after page load

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,3 +12,9 @@ const Boundary = window.ErrorBoundary || React.Fragment;
 
 root.render(createElement(Boundary, null, createElement(App)));
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('./sw.js');
+  });
+}
+


### PR DESCRIPTION
## Summary
- register `sw.js` service worker after window load if supported

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c022df9d40832d99140b6ad97a234c