### PR TITLE
Cache React libraries and bump service worker cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'javelin-checklist-v1';
+const CACHE_NAME = 'javelin-checklist-v2';
 const FILES_TO_CACHE = [
   '.',
   'index.html',
@@ -10,7 +10,9 @@ const FILES_TO_CACHE = [
   'sw.js',
   'tasks.js',
   'https://cdn.jsdelivr.net/npm/lucide@latest/dist/lucide.min.js',
-  'https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js'
+  'https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js',
+  'https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js',
+  'https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js'
 ];
 self.addEventListener('install', evt => {
   evt.waitUntil(


### PR DESCRIPTION
## Summary
- cache React and React DOM CDN scripts in the service worker
- bump cache name to invalidate old caches

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c022e76e2c832dbfe7cfc119d2fb72