### PR TITLE
Allow workouts without baseline plan

### DIFF
--- a/tasks.js
+++ b/tasks.js
@@ -41,9 +41,8 @@ function addCustomTask(task) {
 function getTasksFor(dayKey, date) {
   const hist = loadTaskHistory();
   const plans = hist[dayKey] || [];
-  if (!plans.length) return {};
   const target = date.toISOString().split('T')[0];
-  let result = plans[0].tasks;
+  let result = plans.length ? plans[0].tasks : {};
   for (const p of plans) {
     if (p.start <= target) result = p.tasks; else break;
   }


### PR DESCRIPTION
## Summary
- Ensure getTasksFor initializes an empty task list when no plan exists
- Permit custom tasks and workouts to populate tasks even without a baseline plan

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d79a625c832d9ef6551cae313fc4